### PR TITLE
Add !help command

### DIFF
--- a/src/dispatch/args.rs
+++ b/src/dispatch/args.rs
@@ -24,6 +24,7 @@ use crate::modules::no_bot::deny_bot_mod;
 use crate::modules::config::config_mod;
 use crate::modules::roles::roles_module;
 use crate::modules::me::me_mod;
+use crate::modules::help::help_module;
 
 #[doc(hidden)]
 pub fn command_parser() -> App<'static, 'static> {
@@ -42,6 +43,7 @@ pub fn handle_matches(m: &ArgMatches) -> anyhow::Result<()> {
             .with_module(config_mod())
             .with_module(roles_module())
             .with_module(ping_module())
+            .with_module(help_module())
             .with_module(me_mod());
         let mut client = Client::new(token, dispatch)?;
         client.start_autosharded()?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -78,8 +78,7 @@ fn main() -> anyhow::Result<()> {
     let verbosity = match matches.occurrences_of("verbosity") {
         0 => LevelFilter::Info,
         1 => LevelFilter::Debug,
-        i if i >= 2 => LevelFilter::Trace,
-        _ => unreachable!()
+        _ /* >= 2 */ => LevelFilter::Trace,
     };
 
     init_logging(verbosity)?;

--- a/src/modules/help.rs
+++ b/src/modules/help.rs
@@ -1,0 +1,60 @@
+//  Glimbot - A Discord anti-spam and administration bot.
+//  Copyright (C) 2020 Nick Samson
+
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+//! Lists out the help for all the commands
+
+use std::borrow::Cow;
+
+use serenity::model::channel::Message;
+use serenity::prelude::Context;
+use serenity::utils::MessageBuilder;
+
+use crate::dispatch::Dispatch;
+use crate::error::AnyError;
+use crate::modules::Module;
+use crate::modules::commands::Command;
+use crate::modules::commands::Result;
+
+/// Command that tells an user information about installed commands
+#[derive(Copy, Clone, Debug)]
+pub struct Help;
+
+impl Command for Help {
+    fn invoke(&self, disp: &Dispatch, ctx: &Context, msg: &Message, _args: Cow<str>) -> Result<()> {
+        trace!("Help wanted from user {:?}", msg.author.id);
+
+        let mut builder = MessageBuilder::new();
+        for module in disp.modules().values() {
+            builder.push_bold_line_safe(module.name());
+
+            builder.push_codeblock_safe(
+                &module.command_handler.as_ref().map_or(Cow::from("No command"), |cmd| cmd.help()), 
+                None
+            );
+        }
+
+        let content = builder.build();
+        msg.channel_id.say(&ctx.http, content).map_err(AnyError::boxed)?;
+        Ok(())
+    }
+}
+
+/// Creates a new help module.
+pub fn help_module() -> Module {
+    Module::with_name("help")
+        .with_command(Help)
+        .with_sensitivity(false)
+}

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -31,6 +31,7 @@ pub mod no_bot;
 pub mod config;
 pub mod roles;
 pub mod me;
+pub mod help;
 
 /// An integrated unit of functionality for Glimbot. A module may have a command module associated with it,
 /// and one or more hooks.


### PR DESCRIPTION
This is still a draft as I've not been able to test it (I'm trying to wait for WSL2 since they may update is out, just not for my machine, 😞) but I thought that making a branch & draft PR would be good for communication.

The approach here is *very* simplistic: For each `Module`, output its name as a bolded line and then output a codeblock with its command handler's `Command::help` (or "No command." if there is none).

Let me know what you think of this approach and I'll refine it as needed.

Closes: #4 